### PR TITLE
Add Docstring API Documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,7 @@ include = ["src"]
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["COM812", "D"]
+ignore = ["COM812", "D203", "D213"]
+
+[tool.ruff.lint.per-file-ignores]
+"examples/*" = ["D"]

--- a/src/cursers/__init__.py
+++ b/src/cursers/__init__.py
@@ -1,3 +1,5 @@
+"""Cursers: A minimal threaded wrapper for Python curses."""
+
 from .app import App, ThreadedApp
 from .thread import Thread
 

--- a/src/cursers/app.py
+++ b/src/cursers/app.py
@@ -1,3 +1,5 @@
+"""Core application classes for the cursers library."""
+
 import curses
 import time
 from typing import Self
@@ -6,12 +8,26 @@ from .thread import Thread
 
 
 class App:
+    """Context manager that provides curses application framework.
+
+    The App class handles curses initialization and cleanup,
+    provides an update loop with configurable FPS, and offers
+    lifecycle hooks for application logic.
+    """
+
     def __init__(self, *, fps: int = 30) -> None:
+        """Initialize the application.
+
+        Args:
+            fps: Target frames per second for the update loop.
+
+        """
         self.stdscr = None
         self._fps = fps
         self._is_running = False
 
     def __enter__(self) -> Self:
+        """Enter the application context and initialize curses."""
         self.stdscr = curses.initscr()
         self.stdscr.nodelay(True)  # noqa: FBT003
         curses.curs_set(0)
@@ -23,14 +39,17 @@ class App:
         return self
 
     def __exit__(self, *args: object) -> None:
+        """Exit the application context and cleanup curses."""
         self._is_running = False
         self.on_exit()
         curses.endwin()
 
     def is_running(self) -> bool:
+        """Check if the application is currently running."""
         return self._is_running
 
     def update(self) -> None:
+        """Update the application state and handle input."""
         if self._is_running:
             key = self.stdscr.getch()
             self.on_update(key)
@@ -38,37 +57,63 @@ class App:
             time.sleep(1 / self._fps)
 
     def exit(self) -> None:
+        """Signal the application to exit."""
         self._is_running = False
 
     def on_enter(self) -> None:
-        pass
+        """Handle application entry into the context."""
 
     def on_update(self, key: int) -> None:
-        pass
+        """Handle frame updates with the current key input.
+
+        Args:
+            key: Key code from getch(), or -1 if no key pressed.
+
+        """
 
     def on_exit(self) -> None:
-        pass
+        """Handle application exit from the context."""
 
     def draw_text(self, y: int, x: int, text: str, *, bold: bool = False) -> None:
+        """Draw text to the screen at the specified position.
+
+        Args:
+            y: Row position.
+            x: Column position.
+            text: Text to draw.
+            bold: Whether to draw in bold style.
+
+        """
         attr = curses.A_BOLD if bold else curses.A_NORMAL
         self.stdscr.addstr(y, x, text, attr)
 
 
 class ThreadedApp(App, Thread):
+    """Threaded version of App that runs the update loop in a separate thread."""
+
     def __init__(self, *, fps: int = 30) -> None:
+        """Initialize the threaded application.
+
+        Args:
+            fps: Target frames per second for the update loop.
+
+        """
         App.__init__(self, fps=fps)
         Thread.__init__(self)
 
     def __enter__(self) -> Self:
+        """Enter the application context and start the thread."""
         App.__enter__(self)
         Thread.__enter__(self)
         return self
 
     def __exit__(self, *args: object) -> None:
+        """Exit the application context and join the thread."""
         App.__exit__(self)
         Thread.__exit__(self)
 
     def run(self) -> None:
+        """Run the update loop in the thread."""
         while self.is_running():
             self.update()
 

--- a/src/cursers/thread.py
+++ b/src/cursers/thread.py
@@ -1,23 +1,30 @@
+"""Threading utilities for the cursers library."""
+
 import threading
 from typing import Self
 
 
 class Thread:
+    """Context manager that provides threading functionality."""
+
     def __init__(self) -> None:
+        """Initialize the thread manager."""
         self._thread = None
 
     def __enter__(self) -> Self:
+        """Enter the context and start the thread."""
         self._thread = threading.Thread(target=self.run)
         self._thread.start()
         return self
 
     def __exit__(self, *args: object) -> None:
+        """Exit the context and join the thread."""
         if self._thread is not None:
             self._thread.join()
             self._thread = None
 
     def run(self) -> None:
-        pass
+        """Execute the target method for the thread. Override in subclasses."""
 
 
 __all__ = ["Thread"]


### PR DESCRIPTION
This pull request resolves #11 by adding docstring-based API documentation to all public modules, classes, and methods. This change also enables the [pydocstyle (`D`)](https://docs.astral.sh/ruff/rules/#pydocstyle-d) linter rules, except in the `examples` directory.
