### PR TITLE
Use dprint to Format Source Code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Install Dependencies
         run: uv sync --locked
 
-      - name: Check Format
-        run: uv run ruff format --diff
+      - name: Check Formatting
+        uses: dprint/check@v2.3
 
       - name: Check Lint
         run: uv run ruff check

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.20.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.19.0.wasm",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm",
+    "https://plugins.dprint.dev/ruff-0.4.1.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
+  ]
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
       run: uv run ruff format
 
     - name: fix lint
-      run: uv run ruff check --fix
+      run: dprint fmt
 
     - name: check diff
       run: git diff --exit-code uv.lock {staged_files}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,22 +4,22 @@ version = "0.1.0"
 dependencies = []
 requires-python = ">=3.13"
 authors = [
-    {name = "Alfi Maulana", email = "alfi.maulana.f@gmail.com"},
+  { name = "Alfi Maulana", email = "alfi.maulana.f@gmail.com" },
 ]
 description = "A minimal threaded wrapper for Python curses "
 readme = "README.md"
 license = "MIT"
 keywords = ["curses", "terminal", "tui", "threading", "wrapper"]
 classifiers = [
-    "Development Status :: 1 - Planning",
-    "Environment :: Console",
-    "Environment :: Console :: Curses",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.13",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Terminals",
+  "Development Status :: 1 - Planning",
+  "Environment :: Console",
+  "Environment :: Console :: Curses",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Terminals",
 ]
 
 [project.urls]
@@ -32,8 +32,8 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "lefthook>=1.11.14",
-    "ruff>=0.11.13",
+  "lefthook>=1.11.14",
+  "ruff>=0.11.13",
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
This pull request resolves #13 by utilizing [dprint](https://dprint.dev/) to format the source code in this project, expanding the formatting to cover all configuration files in addition to the Python source files.
