### PR TITLE
Add More URLs to Project Metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
 ]
 
 [project.urls]
+homepage = "https://pypi.org/project/cursers/"
 repository = "https://github.com/threeal/cursers.git"
+documentation = "https://threeal.github.io/cursers/"
 issues = "https://github.com/threeal/cursers/issues"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ include = ["src"]
 [tool.pydoctor]
 add-package = ["src/cursers"]
 docformat = "google"
+project-url = "https://pypi.org/project/cursers/"
 theme = "readthedocs"
 warnings-as-errors = true
 


### PR DESCRIPTION
This pull request resolves #28 by adding more URLs to the project metadata in the `pyproject.toml` file, including the homepage, documentation, and project URL for the API documentation.
