### PR TITLE
Fix Arrow Keys Being Treated as Escape Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ The main application class that provides a context manager for curses applicatio
 #### Constructor
 
 ```python
-App(fps=30)
+App(fps=30, keypad=False)
 ```
 
 - `fps`: Target frames per second (default: 30)
+- `keypad`: Whether to enable arrow keys and function keys (default: False)
 
 #### Methods
 

--- a/examples/move_control.py
+++ b/examples/move_control.py
@@ -3,7 +3,7 @@ import cursers
 
 class MoveControlApp(cursers.App):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(keypad=True)
         self.y = 0
         self.x = 0
 

--- a/examples/move_control_gravity.py
+++ b/examples/move_control_gravity.py
@@ -6,7 +6,7 @@ import cursers
 
 class MoveControlApp(cursers.ThreadedApp):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(keypad=True)
 
         self.lock = threading.Lock()
         self.y = 0

--- a/src/cursers/__init__.py
+++ b/src/cursers/__init__.py
@@ -24,15 +24,17 @@ class App:
     with configurable FPS, and offers lifecycle hooks for application logic.
     """
 
-    def __init__(self, *, fps: int = 30) -> None:
+    def __init__(self, *, fps: int = 30, keypad: bool = False) -> None:
         """Initialize the application.
 
         Args:
             fps: Target frames per second (default: 30).
+            keypad: Whether to enable arrow keys (default: False).
 
         """
         self._stdscr = None
         self._fps = fps
+        self._keypad = keypad
         self._is_running = False
 
     def __enter__(self) -> Self:
@@ -44,6 +46,9 @@ class App:
         """
         self._stdscr = curses.initscr()
         self._stdscr.nodelay(True)  # noqa: FBT003
+        if self._keypad:
+            self._stdscr.keypad(True)  # noqa: FBT003
+
         curses.curs_set(0)
         curses.noecho()
 
@@ -191,14 +196,15 @@ class ThreadedApp(App, Thread):
     the background.
     """
 
-    def __init__(self, *, fps: int = 30) -> None:
+    def __init__(self, *, fps: int = 30, keypad: bool = False) -> None:
         """Initialize the threaded application.
 
         Args:
             fps: Target frames per second (default: 30).
+            keypad: Whether to enable arrow keys (default: False).
 
         """
-        App.__init__(self, fps=fps)
+        App.__init__(self, fps=fps, keypad=keypad)
         Thread.__init__(self)
 
     def __enter__(self) -> Self:


### PR DESCRIPTION
This pull request resolves #34 by adding a new `keypad` option to the `App` and `ThreadedApp` classes. It also updates the examples to enable the `keypad` option, allowing arrow keys to be distinguished from the Escape key.
