### PR TITLE
Only Allow Screen Drawing Inside Lifecycle Callbacks

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -20,11 +20,12 @@ import cursers
 
 class MyApp(cursers.App):
     # Called when entering the application context
-    def on_enter(self):
-        self.draw_text(0, 0, "Hello, World!", bold=True)
+    def on_enter(self, screen):
+        screen.draw_text(0, 0, "Hello, World!", bold=True)
 
-    # Called each frame with the current key input
-    def on_update(self, key):
+    # Called each frame with screen object for input/drawing
+    def on_update(self, screen):
+        key = screen.get_key()
         if key == 27:  # ESC key
             self.exit()
 
@@ -43,10 +44,11 @@ import time
 
 
 class MyThreadedApp(cursers.ThreadedApp):
-    def on_enter(self):
-        self.draw_text(0, 0, "Running in background thread!")
+    def on_enter(self, screen):
+        screen.draw_text(0, 0, "Running in background thread!")
 
-    def on_update(self, key):
+    def on_update(self, screen):
+        key = screen.get_key()
         if key == 27:  # ESC key
             self.exit()
 
@@ -68,25 +70,25 @@ The main application class that provides a context manager for curses applicatio
 #### Constructor
 
 ```python
-App(fps=30)
+App(fps=30, keypad=False)
 ```
 
 - `fps`: Target frames per second (default: 30)
+- `keypad`: Whether to enable arrow keys and function keys (default: False)
 
 #### Methods
 
 - `is_running()`: Returns `True` if the application is running
 - `update()`: Updates the application state and handles input (call in main loop)
 - `exit()`: Signals the application to exit
-- `draw_text(y, x, text, bold=False, underline=False)`: Draw text at position
 
 #### Lifecycle Hooks
 
 Override these methods in your subclass:
 
-- `on_enter()`: Called when entering the context
-- `on_update(key)`: Called every frame with key input (-1 if no key pressed)
-- `on_exit()`: Called when exiting the context
+- `on_enter(screen)`: Called when entering the context
+- `on_update(screen)`: Called every frame
+- `on_exit(screen)`: Called when exiting the context
 
 ### ThreadedApp Class
 
@@ -94,8 +96,9 @@ Extends `App` to run the update loop in a separate thread.
 
 ```python
 class MyThreadedApp(cursers.ThreadedApp):
-    def on_update(self, key):
+    def on_update(self, screen):
         # Handle input and drawing
+        key = screen.get_key()
         pass
 
 
@@ -105,6 +108,16 @@ with MyThreadedApp() as app:
         # Main thread is free for other tasks
         time.sleep(0.1)
 ```
+
+### Screen Class
+
+Low-level screen management for curses applications. Provides direct access to curses screen operations.
+
+#### Methods
+
+- `get_key()`: Returns the next key code from input buffer (-1 if no key available)
+- `refresh()`: Refreshes the screen to display pending changes
+- `draw_text(y, x, text, bold=False, underline=False)`: Draw styled text at position
 
 ### Thread Class
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ import cursers
 
 class MyApp(cursers.App):
     # Called when entering the application context
-    def on_enter(self):
-        self.draw_text(0, 0, "Hello, World!", bold=True)
+    def on_enter(self, screen):
+        screen.draw_text(0, 0, "Hello, World!", bold=True)
 
-    # Called each frame with the current key input
-    def on_update(self, key):
+    # Called each frame with screen object for input/drawing
+    def on_update(self, screen):
+        key = screen.get_key()
         if key == 27:  # ESC key
             self.exit()
 
@@ -49,10 +50,11 @@ import time
 
 
 class MyThreadedApp(cursers.ThreadedApp):
-    def on_enter(self):
-        self.draw_text(0, 0, "Running in background thread!")
+    def on_enter(self, screen):
+        screen.draw_text(0, 0, "Running in background thread!")
 
-    def on_update(self, key):
+    def on_update(self, screen):
+        key = screen.get_key()
         if key == 27:  # ESC key
             self.exit()
 
@@ -85,15 +87,14 @@ App(fps=30, keypad=False)
 - `is_running()`: Returns `True` if the application is running
 - `update()`: Updates the application state and handles input (call in main loop)
 - `exit()`: Signals the application to exit
-- `draw_text(y, x, text, bold=False, underline=False)`: Draw text at position
 
 #### Lifecycle Hooks
 
 Override these methods in your subclass:
 
-- `on_enter()`: Called when entering the context
-- `on_update(key)`: Called every frame with key input (-1 if no key pressed)
-- `on_exit()`: Called when exiting the context
+- `on_enter(screen)`: Called when entering the context
+- `on_update(screen)`: Called every frame
+- `on_exit(screen)`: Called when exiting the context
 
 ### ThreadedApp Class
 
@@ -101,8 +102,9 @@ Extends `App` to run the update loop in a separate thread.
 
 ```python
 class MyThreadedApp(cursers.ThreadedApp):
-    def on_update(self, key):
+    def on_update(self, screen):
         # Handle input and drawing
+        key = screen.get_key()
         pass
 
 
@@ -112,6 +114,16 @@ with MyThreadedApp() as app:
         # Main thread is free for other tasks
         time.sleep(0.1)
 ```
+
+### Screen Class
+
+Low-level screen management for curses applications. Provides direct access to curses screen operations.
+
+#### Methods
+
+- `get_key()`: Returns the next key code from input buffer (-1 if no key available)
+- `refresh()`: Refreshes the screen to display pending changes
+- `draw_text(y, x, text, bold=False, underline=False)`: Draw styled text at position
 
 ### Thread Class
 

--- a/examples/move_control.py
+++ b/examples/move_control.py
@@ -7,18 +7,19 @@ class MoveControlApp(cursers.App):
         self.y = 0
         self.x = 0
 
-    def on_enter(self) -> None:
-        self.draw_text(0, 7, "Movement Control", bold=True, underline=True)
+    def on_enter(self, screen: cursers.Screen) -> None:
+        screen.draw_text(0, 7, "Movement Control", bold=True, underline=True)
 
-        self.draw_text(3, 2, f"X coordinate: {self.x:12}")
-        self.draw_text(4, 2, f"Y coordinate: {self.y:12}")
+        screen.draw_text(3, 2, f"X coordinate: {self.x:12}")
+        screen.draw_text(4, 2, f"Y coordinate: {self.y:12}")
 
-        self.draw_text(7, 2, "Keyboard Controls:", bold=True)
-        self.draw_text(8, 4, "W/S - Move up/down")
-        self.draw_text(9, 4, "A/D - Move left/right")
-        self.draw_text(10, 4, "ESC - Exit app", bold=True)
+        screen.draw_text(7, 2, "Keyboard Controls:", bold=True)
+        screen.draw_text(8, 4, "W/S - Move up/down")
+        screen.draw_text(9, 4, "A/D - Move left/right")
+        screen.draw_text(10, 4, "ESC - Exit app", bold=True)
 
-    def on_update(self, key: int) -> None:
+    def on_update(self, screen: cursers.Screen) -> None:
+        key = screen.get_key()
         match chr(key) if key != -1 else None:
             case "\x1b":  # ESC
                 self.exit()
@@ -32,8 +33,8 @@ class MoveControlApp(cursers.App):
             case "d" | "D":
                 self.x += 1
 
-        self.draw_text(3, 16, f"{self.x:12}")
-        self.draw_text(4, 16, f"{self.y:12}")
+        screen.draw_text(3, 16, f"{self.x:12}")
+        screen.draw_text(4, 16, f"{self.y:12}")
 
 
 if __name__ == "__main__":

--- a/examples/move_control_gravity.py
+++ b/examples/move_control_gravity.py
@@ -12,19 +12,21 @@ class MoveControlApp(cursers.ThreadedApp):
         self.y = 0
         self.x = 0
 
-    def on_enter(self) -> None:
-        self.draw_text(0, 1, "Movement Control with Gravity", bold=True, underline=True)
+    def on_enter(self, screen: cursers.Screen) -> None:
+        title = "Movement Control with Gravity"
+        screen.draw_text(0, 1, title, bold=True, underline=True)
 
-        self.draw_text(3, 2, f"X coordinate: {self.x:12}")
-        self.draw_text(4, 2, f"Y coordinate: {self.y:12}")
+        screen.draw_text(3, 2, f"X coordinate: {self.x:12}")
+        screen.draw_text(4, 2, f"Y coordinate: {self.y:12}")
 
-        self.draw_text(7, 2, "Keyboard Controls:", bold=True)
-        self.draw_text(8, 4, "W/S - Move up/down")
-        self.draw_text(9, 4, "A/D - Move left/right")
-        self.draw_text(10, 4, "ESC - Exit app", bold=True)
+        screen.draw_text(7, 2, "Keyboard Controls:", bold=True)
+        screen.draw_text(8, 4, "W/S - Move up/down")
+        screen.draw_text(9, 4, "A/D - Move left/right")
+        screen.draw_text(10, 4, "ESC - Exit app", bold=True)
 
-    def on_update(self, key: int) -> None:
+    def on_update(self, screen: cursers.Screen) -> None:
         with self.lock:
+            key = screen.get_key()
             match chr(key) if key != -1 else None:
                 case "\x1b":  # ESC
                     self.exit()
@@ -38,8 +40,8 @@ class MoveControlApp(cursers.ThreadedApp):
                 case "d" | "D":
                     self.x += 1
 
-            self.draw_text(3, 16, f"{self.x:12}")
-            self.draw_text(4, 16, f"{self.y:12}")
+            screen.draw_text(3, 16, f"{self.x:12}")
+            screen.draw_text(4, 16, f"{self.y:12}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request resolves #36 by allowing screen drawing only inside the lifecycle callbacks. To implement this, it introduces a new `Screen` class and modifies the `on_enter`, `on_update`, and `on_exit` callbacks to include the `Screen` class as a parameter.