### PR TITLE
Rename Exit Method to Request Exit

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -27,12 +27,12 @@ class MyApp(cursers.App):
     def on_update(self, screen):
         key = screen.get_key()
         if key == 27:  # ESC key
-            self.exit()
+            self.request_exit()
 
 
 # Run the application
 with MyApp() as app:
-    while app.is_running():
+    while not app.is_exit_requested():
         app.update()
 ```
 
@@ -50,12 +50,12 @@ class MyThreadedApp(cursers.ThreadedApp):
     def on_update(self, screen):
         key = screen.get_key()
         if key == 27:  # ESC key
-            self.exit()
+            self.request_exit()
 
 
 # Run in background thread
 with MyThreadedApp() as app:
-    while app.is_running():
+    while not app.is_exit_requested():
         time.sleep(0.1)  # Do other work
 ```
 
@@ -78,9 +78,9 @@ App(fps=30, keypad=False)
 
 #### Methods
 
-- `is_running()`: Returns `True` if the application is running
+- `request_exit()`: Requests the application to exit
+- `is_exit_requested()`: Returns `True` if exit has been requested
 - `update()`: Updates the application state and handles input (call in main loop)
-- `exit()`: Signals the application to exit
 
 #### Lifecycle Hooks
 
@@ -104,7 +104,7 @@ class MyThreadedApp(cursers.ThreadedApp):
 
 with MyThreadedApp() as app:
     # Update loop runs automatically in background thread
-    while app.is_running():
+    while not app.is_exit_requested():
         # Main thread is free for other tasks
         time.sleep(0.1)
 ```

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ class MyApp(cursers.App):
     def on_update(self, screen):
         key = screen.get_key()
         if key == 27:  # ESC key
-            self.exit()
+            self.request_exit()
 
 
 # Run the application
 with MyApp() as app:
-    while app.is_running():
+    while not app.is_exit_requested():
         app.update()
 ```
 
@@ -56,12 +56,12 @@ class MyThreadedApp(cursers.ThreadedApp):
     def on_update(self, screen):
         key = screen.get_key()
         if key == 27:  # ESC key
-            self.exit()
+            self.request_exit()
 
 
 # Run in background thread
 with MyThreadedApp() as app:
-    while app.is_running():
+    while not app.is_exit_requested():
         time.sleep(0.1)  # Do other work
 ```
 
@@ -84,9 +84,9 @@ App(fps=30, keypad=False)
 
 #### Methods
 
-- `is_running()`: Returns `True` if the application is running
+- `request_exit()`: Requests the application to exit
+- `is_exit_requested()`: Returns `True` if exit has been requested
 - `update()`: Updates the application state and handles input (call in main loop)
-- `exit()`: Signals the application to exit
 
 #### Lifecycle Hooks
 
@@ -110,7 +110,7 @@ class MyThreadedApp(cursers.ThreadedApp):
 
 with MyThreadedApp() as app:
     # Update loop runs automatically in background thread
-    while app.is_running():
+    while not app.is_exit_requested():
         # Main thread is free for other tasks
         time.sleep(0.1)
 ```

--- a/examples/move_control.py
+++ b/examples/move_control.py
@@ -22,7 +22,7 @@ class MoveControlApp(cursers.App):
         key = screen.get_key()
         match chr(key) if key != -1 else None:
             case "\x1b":  # ESC
-                self.exit()
+                self.request_exit()
                 return
             case "w" | "W":
                 self.y -= 1
@@ -39,5 +39,5 @@ class MoveControlApp(cursers.App):
 
 if __name__ == "__main__":
     with MoveControlApp() as app:
-        while app.is_running():
+        while not app.is_exit_requested():
             app.update()

--- a/examples/move_control_gravity.py
+++ b/examples/move_control_gravity.py
@@ -29,7 +29,7 @@ class MoveControlApp(cursers.ThreadedApp):
             key = screen.get_key()
             match chr(key) if key != -1 else None:
                 case "\x1b":  # ESC
-                    self.exit()
+                    self.request_exit()
                     return
                 case "w" | "W":
                     self.y -= 1
@@ -46,7 +46,7 @@ class MoveControlApp(cursers.ThreadedApp):
 
 if __name__ == "__main__":
     with MoveControlApp() as app:
-        while app.is_running():
+        while app.is_exit_requested():
             with app.lock:
                 app.y += 1
 

--- a/src/cursers/__init__.py
+++ b/src/cursers/__init__.py
@@ -141,10 +141,9 @@ class App:
         Call this method in your main loop to update the application state
         and handle keyboard input.
         """
-        if not self._is_exit_requested:
-            self.on_update(self._screen)
-            self._screen.refresh()
-            time.sleep(1 / self._fps)
+        self.on_update(self._screen)
+        self._screen.refresh()
+        time.sleep(1 / self._fps)
 
     def on_enter(self, screen: Screen) -> None:
         """Handle entering the application context.

--- a/src/cursers/__init__.py
+++ b/src/cursers/__init__.py
@@ -90,7 +90,7 @@ class App:
         self._screen = None
         self._fps = fps
         self._keypad = keypad
-        self._is_running = False
+        self._is_exit_requested = False
 
     def __enter__(self) -> Self:
         """Enter the application context and initialize curses.
@@ -103,8 +103,8 @@ class App:
         curses.curs_set(0)
         curses.noecho()
 
+        self.__is_exit_requested = False
         self.on_enter(self._screen)
-        self._is_running = True
 
         return self
 
@@ -115,18 +115,25 @@ class App:
             *args: Exception information (unused).
 
         """
-        self._is_running = False
         self.on_exit(self._screen)
         curses.endwin()
 
-    def is_running(self) -> bool:
-        """Check if the application is currently running.
+    def request_exit(self) -> None:
+        """Request the application to exit.
+
+        Sets the exit flag to True, which will cause the application
+        to exit on the next update cycle.
+        """
+        self.__is_exit_requested = True
+
+    def is_exit_requested(self) -> bool:
+        """Check if an exit has been requested.
 
         Returns:
-            True if the application is running, False otherwise.
+            True if exit has been requested, False otherwise.
 
         """
-        return self._is_running
+        return self.__is_exit_requested
 
     def update(self) -> None:
         """Update the application state and handle input.
@@ -134,18 +141,10 @@ class App:
         Call this method in your main loop to update the application state
         and handle keyboard input.
         """
-        if self._is_running:
+        if not self._is_exit_requested:
             self.on_update(self._screen)
             self._screen.refresh()
             time.sleep(1 / self._fps)
-
-    def exit(self) -> None:
-        """Signal the application to exit.
-
-        Sets the running state to False, which will cause the application
-        to exit on the next update cycle.
-        """
-        self._is_running = False
 
     def on_enter(self, screen: Screen) -> None:
         """Handle entering the application context.
@@ -271,7 +270,7 @@ class ThreadedApp(App, Thread):
         This method is called automatically when the thread starts.
         It continuously calls update() while the application is running.
         """
-        while self.is_running():
+        while not self.is_exit_requested():
             self.update()
 
 


### PR DESCRIPTION
This pull request resolves #38 by renaming the `App.exit` method to `App.request_exit` and the `App.is_running` method to `App.is_exit_requested`. This change also allows `App.update` to be called even after an exit has been requested.