### PR TITLE
Bump dprint Ruff Plugin to version 0.5.0

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -3,7 +3,7 @@
     "https://plugins.dprint.dev/json-0.20.0.wasm",
     "https://plugins.dprint.dev/markdown-0.19.0.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm",
-    "https://plugins.dprint.dev/ruff-0.4.10.wasm",
+    "https://plugins.dprint.dev/ruff-0.5.0.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
   ]
 }


### PR DESCRIPTION
This pull request bumps [dprint Ruff Plugin](https://dprint.dev/plugins/ruff/) to version 0.5.0.